### PR TITLE
Update Util.pm

### DIFF
--- a/lib/Moo/Google/Util.pm
+++ b/lib/Moo/Google/Util.pm
@@ -38,7 +38,7 @@ sub substitute_placeholders {
     my ( $self, $string, $parameters ) = @_;
 
     # find all parameters in string
-    my @matches = $string =~ /{([a-zA-Z_]+)}/g;
+    my @matches = $string =~ /{[-+]?([a-zA-Z_]+)}/g;
 
     warn "Util substitute_placeholders() matches: " . Dumper \@matches
       if ( $self->debug );
@@ -50,7 +50,7 @@ sub substitute_placeholders {
             my $s = $parameters->{$prm};
             warn "Value of " . $prm . " took from passed parameters: " . $s
               if ( $self->debug );
-            $string =~ s/{$prm}/$s/g;
+            $string =~ s/{[+-]?$prm}/$s/g;
 
             #}
             #  elsif (defined $self->$prm) {


### PR DESCRIPTION
Added a prefix check for + or - on JSON variables.  Without this, some substitutions were not being matched, causing failures in various API methods.  For instance, this is the case with the Slides API (https://slides.googleapis.com/$discovery/rest?version=v1) with the "path": "v1/presentations/{+presentationId}" declaration.